### PR TITLE
Add Claude Certification link to footer

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -139,6 +139,14 @@ export default function Footer() {
                   Guías
                 </Link>
               </li>
+              <li>
+                <Link
+                  href="/claude"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Certificación Claude Code
+                </Link>
+              </li>
             </ul>
           </div>
           <div>


### PR DESCRIPTION
Added a new link to the footer in the "Recursos" column. The link points to "/claude" and has the text "Certificación Claude Code". This change follows the existing styling and structure of the Footer component.

Fixes #19

---
*PR created automatically by Jules for task [1972157528327974440](https://jules.google.com/task/1972157528327974440) started by @angelolev*