### PR TITLE
Update footer year to be dynamic

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -196,7 +196,7 @@ export default function Footer() {
           </div>
         </div>
         <div className="mt-12 pt-8 border-t border-gray-800 text-center text-gray-400">
-          <p>© 2025 Coding Latam. Todos los derechos reservados.</p>
+          <p>© {new Date().getFullYear()} Coding Latam. Todos los derechos reservados.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
The copyright year in the footer was hardcoded to 2025. I updated it to use a dynamic value using `new Date().getFullYear()`. This ensures that the footer will always display the current year without manual updates. Verified the change in `src/components/Footer/index.tsx`.

Fixes #22

---
*PR created automatically by Jules for task [18090468545588859297](https://jules.google.com/task/18090468545588859297) started by @angelolev*